### PR TITLE
Endpoints for changing pay rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,11 @@ curl -X GET "http://127.0.0.1:8080/time/get" \
 
 curl -X GET "http://127.0.0.1:8080/time/employees" \
                 -H "Authorization: Bearer $TOKEN"
+
+curl -X GET "http://127.0.0.1:8080/employee/pay" \
+                -H "Authorization: Bearer $TOKEN"
+
+curl -X POST "http://127.0.0.1:8080/employee/pay" \
+                -H "Authorization: Bearer $TOKEN" \
+                -d pay_rate=23.78
 ```

--- a/timepunch/urls.py
+++ b/timepunch/urls.py
@@ -22,6 +22,7 @@ from auth_user.views import (
     AddEmployees,
     RemoveEmployees,
     GetEmployees,
+    EmployeePay,
 )
 from time_log.views import LogTime, GetTime, GetEmployeeTime
 
@@ -36,4 +37,5 @@ urlpatterns = [
     path("time/log", LogTime.as_view()),
     path("time/get", GetTime.as_view()),
     path("time/employees", GetEmployeeTime.as_view()),
+    path("employee/pay", EmployeePay.as_view()),
 ]


### PR DESCRIPTION
Pull request for #5 

```
$ curl -X GET "http://127.0.0.1:8080/employee/pay" -H "Authorization: Bearer $TOKEN"
{"pay_rate": "23.60"}
$ curl -X POST "http://127.0.0.1:8080/employee/pay" -H "Authorization: Bearer $TOKEN" -d pay_rate=23.78
{"user_modified": true}
$ curl -X GET "http://127.0.0.1:8080/employee/pay" -H "Authorization: Bearer $TOKEN"
{"pay_rate": "23.78"}
$ curl -X POST "http://127.0.0.1:8080/employee/pay" -H "Authorization: Bearer $TOKEN" -d pay_rate=asdf
{"user_modified": false, "errors": "pay_rate is not a valid float"}
```
I haven't figured out how to check the status of validating the pay_rate in POST (see TODO in code). It seems to not update the value in the database when validation fails, but I am unsure how to detect validation failure and report that to the requester.
