### PR TITLE
pay rate validation fix

### DIFF
--- a/auth_user/views.py
+++ b/auth_user/views.py
@@ -165,6 +165,14 @@ class EmployeePay(APIView):
     @guarantee_auth
     def post(self, request, user: CustomAccount):
         params = request.POST.dict()
+        if "pay_rate" not in params:
+            return JsonResponse(
+                {
+                    "user_modified": False,
+                    "errors": "pay_rate is missing",
+                },
+                status=500,
+            )
         try:
             user.pay_rate = params["pay_rate"]
             user.clean_fields()


### PR DESCRIPTION
Fixes for #17 

Before, certain invalid pay rates with too many decimal places would not give an error and quietly not update the database.
Now:
```
$ curl -X POST "http://127.0.0.1:8080/employee/pay" -H "Authorization: Bearer $TOKEN" -d pay_rate=23.899
{"user_modified": false, "errors": "pay_rate is not a valid float with two decimal places maximum"}
```
Additionally it seems that I didn't properly check for missing pay rate field. Now it should work.